### PR TITLE
QuickCheck properties

### DIFF
--- a/Haskell/BookingApi.cabal
+++ b/Haskell/BookingApi.cabal
@@ -22,3 +22,4 @@ library
                        ,         time >= 1.5 && < 1.6
                        ,          mtl >= 2.2 && < 2.3
                        , transformers >= 0.4 && < 0.5
+                       ,   QuickCheck >= 2.1 && < 3.0

--- a/Haskell/BookingApi.cabal
+++ b/Haskell/BookingApi.cabal
@@ -16,7 +16,7 @@ build-type:          Simple
 cabal-version:       >= 1.10
 
 library
-  exposed-modules:     MaîtreD, Composition, DB
+  exposed-modules:     MaîtreD, MaîtreDTests, Composition, DB
   default-language:    Haskell2010
   build-depends:                 base >= 4.8 && < 4.9
                        ,         time >= 1.5 && < 1.6

--- a/Haskell/MaîtreD.hs
+++ b/Haskell/MaîtreD.hs
@@ -1,10 +1,18 @@
 module MaîtreD where
 
-import Data.Time (ZonedTime)
+import Data.Time (ZonedTime (zonedTimeToLocalTime, zonedTimeZone))
 
 data Reservation =
   Reservation { date :: ZonedTime, quantity :: Int, isAccepted :: Bool }
   deriving (Show)
+
+instance Eq Reservation where
+  x == y =
+       zonedTimeZone        (date x) == zonedTimeZone        (date y)
+    && zonedTimeToLocalTime (date x) == zonedTimeToLocalTime (date y)
+    && quantity                   x  ==  quantity                  y
+    && isAccepted                 x  == isAccepted                 y
+
 
 tryAccept :: Int -> [Reservation] -> Reservation -> Maybe Reservation
 tryAccept capacity reservations reservation =

--- a/Haskell/MaîtreD.hs
+++ b/Haskell/MaîtreD.hs
@@ -1,6 +1,6 @@
 module MaîtreD where
 
-import Data.Time (ZonedTime (zonedTimeToLocalTime, zonedTimeZone))
+import Data.Time (ZonedTime (..))
 
 data Reservation =
   Reservation { date :: ZonedTime, quantity :: Int, isAccepted :: Bool }

--- a/Haskell/MaîtreDTests.hs
+++ b/Haskell/MaîtreDTests.hs
@@ -1,6 +1,9 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module MaîtreDTests where
+module MaîtreDTests
+    ( tryAcceptBehavesCorrectlyWhenItCanAccept
+    , tryAcceptBehavesCorrectlyWhenItCanNotAccept
+    ) where
 
 import           Control.Monad      (liftM2)
 import           Data.Maybe         (isNothing)

--- a/Haskell/MaîtreDTests.hs
+++ b/Haskell/MaîtreDTests.hs
@@ -7,9 +7,10 @@ module MaîtreDTests
 
 import           Control.Monad      (liftM2)
 import           Data.Maybe         (isNothing)
-import           Data.Time          (ZonedTime (..), defaultTimeLocale,
-                                     iso8601DateFormat, parseTimeOrError)
-import           Data.Time.Calendar (gregorianMonthLength)
+import           Data.Time          (LocalTime (..), ZonedTime (..),
+                                     defaultTimeLocale, iso8601DateFormat,
+                                     midnight, parseTimeOrError, utc)
+import           Data.Time.Calendar (fromGregorian, gregorianMonthLength)
 import           MaîtreD
 import           Test.QuickCheck
 import           Text.Printf        (printf)
@@ -19,9 +20,7 @@ instance Arbitrary ZonedTime where
     y <- choose (1, 9999)
     m <- choose (1, 12)
     d <- choose (1, gregorianMonthLength y m)
-    return $
-      (parseTimeOrError True defaultTimeLocale $ iso8601DateFormat Nothing)
-      (printf "%04d" y ++ "-" ++ printf "%02d" m ++ "-" ++ printf "%02d" d)
+    return $ ZonedTime (LocalTime (fromGregorian y m d) midnight) utc
 
 genReservation :: Gen Reservation
 genReservation = do

--- a/Haskell/MaîtreDTests.hs
+++ b/Haskell/MaîtreDTests.hs
@@ -3,6 +3,7 @@
 module MaîtreDTests where
 
 import           Control.Monad      (liftM2)
+import           Data.Maybe         (isNothing)
 import           Data.Time          (ZonedTime (..), defaultTimeLocale,
                                      iso8601DateFormat, parseTimeOrError)
 import           Data.Time.Calendar (gregorianMonthLength)
@@ -45,3 +46,14 @@ tryAcceptBehavesCorrectlyWhenItCanAccept (NonNegative excessCapacity) =
           actual = tryAccept capacity reservations reservation
 
       in Just (reservation { isAccepted = True }) == actual)
+
+tryAcceptBehavesCorrectlyWhenItCanNotAccept :: Positive Int -> Property
+tryAcceptBehavesCorrectlyWhenItCanNotAccept (Positive lackingCapacity) =
+  forAll
+    (liftM2 (,) genReservation $ listOf genReservation)
+    (\(reservation, reservations) ->
+      let capacity = sumBy quantity reservations - lackingCapacity
+
+          actual = tryAccept capacity reservations reservation
+
+      in isNothing actual)

--- a/Haskell/MaîtreDTests.hs
+++ b/Haskell/MaîtreDTests.hs
@@ -7,9 +7,8 @@ module MaîtreDTests
 
 import           Control.Monad      (liftM2)
 import           Data.Maybe         (isNothing)
-import           Data.Time          (LocalTime (..), ZonedTime (..),
-                                     defaultTimeLocale, iso8601DateFormat,
-                                     midnight, parseTimeOrError, utc)
+import           Data.Time          (LocalTime (..), ZonedTime (..), midnight,
+                                     utc)
 import           Data.Time.Calendar (fromGregorian, gregorianMonthLength)
 import           MaîtreD
 import           Test.QuickCheck

--- a/Haskell/MaîtreDTests.hs
+++ b/Haskell/MaîtreDTests.hs
@@ -1,1 +1,45 @@
 module MaîtreDTests where
+
+import           Control.Monad      (liftM2)
+import           Data.Time          (ZonedTime (..), defaultTimeLocale,
+                                     iso8601DateFormat, parseTimeOrError)
+import           Data.Time.Calendar (gregorianMonthLength)
+import           MaîtreD
+import           Test.QuickCheck
+import           Text.Printf        (printf)
+
+instance Arbitrary ZonedTime where
+  arbitrary = do
+    y <- choose (1, 9999)
+    m <- choose (1, 12)
+    d <- choose (1, gregorianMonthLength y m)
+    return $
+      (parseTimeOrError True defaultTimeLocale $ iso8601DateFormat Nothing)
+      (printf "%04d" y ++ "-" ++ printf "%02d" m ++ "-" ++ printf "%02d" d)
+
+genReservation :: Gen Reservation
+genReservation = do
+  bookingDate <- arbitrary
+  Positive qt <- arbitrary
+  trueOrFalse <- arbitrary
+  return Reservation
+    { date       = bookingDate
+    , quantity   = qt
+    , isAccepted = trueOrFalse }
+
+sumBy :: Num a => (b -> a) -> [b] -> a
+sumBy x xs = sum $ map x xs
+
+tryAcceptBehavesCorrectlyWhenItCanAccept :: NonNegative Int -> Property
+tryAcceptBehavesCorrectlyWhenItCanAccept (NonNegative excessCapacity) =
+  forAll
+    (liftM2 (,) genReservation $ listOf genReservation)
+    (\(reservation, reservations) ->
+      let capacity =
+            excessCapacity
+            + sumBy quantity reservations
+            + quantity reservation
+
+          actual = tryAccept capacity reservations reservation
+
+      in Just (reservation { isAccepted = True }) == actual)

--- a/Haskell/MaîtreDTests.hs
+++ b/Haskell/MaîtreDTests.hs
@@ -1,0 +1,1 @@
+module MaîtreDTests where

--- a/Haskell/MaîtreDTests.hs
+++ b/Haskell/MaîtreDTests.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 module MaîtreDTests where
 
 import           Control.Monad      (liftM2)


### PR DESCRIPTION
This pull request adds QuickCheck properties, ported from the FsCheck properties in [MaîtreDTests](https://github.com/ploeh/dependency-rejection-samples/blob/22230733a36f0a425deaafbee14a8922f6df83e6/FSharp/BookingApi/Ma%C3%AEtreDTests.fs).

To automate the execution of these properties (with `stack test` or similar), a [`Test-Suite`](https://www.haskell.org/cabal/users-guide/developing-packages.html#test-suites) section may be added in the .cabal file, on a separate pull request.

---

Until we automate the execution of these properties, we can test them manually with `stack ghci`, like so:

```
$ stack ghci
BookingApi-0.1.0.0: initial-build-steps (lib)
Configuring GHCi with the following packages: BookingApi
GHCi, version 7.10.3: http://www.haskell.org/ghc/  :? for help
[1 of 4] Compiling MaîtreD          ( MaîtreD.hs, interpreted )
[2 of 4] Compiling DB               ( DB.hs, interpreted )
[3 of 4] Compiling Composition      ( Composition.hs, interpreted )
[4 of 4] Compiling MaîtreDTests     ( MaîtreDTests.hs, interpreted )
Ok, modules loaded: MaîtreDTests, MaîtreD, DB, Composition.

*MaîtreDTests Composition DB MaîtreD MaîtreDTests> :set prompt "λ "

λ quickCheck tryAcceptBehavesCorrectlyWhenItCanAccept
+++ OK, passed 100 tests.

λ quickCheck tryAcceptBehavesCorrectlyWhenItCanNotAccept
+++ OK, passed 100 tests.
```

Note that it can be possible that `stack ghci` will not be able to load the modules on Windows because of the *MaîtreDXyz* filenames:

```
$ stack ghci
Configuring GHCi with the following packages: BookingApi
GHCi, version 7.10.3: http://www.haskell.org/ghc/  :? for help
target `Ma├«treD' is not a module name or a source file
syntax:  :module [+/-] [*]M1 ... [*]Mn
Prelude>
```

If so, here's a way to workaround this:

```
$ stack exec ghci
WARNING: GHCi invoked via 'ghci.exe' in *nix-like shells (cygwin-bash, in particular)
         doesn't handle Ctrl-C well; use the 'ghcii.sh' shell wrapper instead
GHCi, version 7.10.3: http://www.haskell.org/ghc/  :? for help

Prelude> :set prompt "λ "

λ :l MaîtreDTests.hs
[1 of 2] Compiling MaîtreD          ( MaîtreD.hs, interpreted )
[2 of 2] Compiling MaîtreDTests     ( MaîtreDTests.hs, interpreted )
Ok, modules loaded: MaîtreD, MaîtreDTests.

λ quickCheck tryAcceptBehavesCorrectlyWhenItCanAccept
+++ OK, passed 100 tests.

λ quickCheck tryAcceptBehavesCorrectlyWhenItCanNotAccept
+++ OK, passed 100 tests.
``` 