### PR TITLE
Add a test-suite section for testing QuickCheck properties

### DIFF
--- a/Haskell/BookingApi.cabal
+++ b/Haskell/BookingApi.cabal
@@ -23,3 +23,12 @@ library
                        ,          mtl >= 2.2 && < 2.3
                        , transformers >= 0.4 && < 0.5
                        ,   QuickCheck >= 2.1 && < 3.0
+
+test-suite discordia
+ type:                exitcode-stdio-1.0
+ main-is:             Discordia.hs
+ other-modules:       MaîtreD, MaîtreDTests
+ default-language:    Haskell2010
+ build-depends:                 base >= 4.8 && < 4.9
+                      ,         time >= 1.5 && < 1.6
+                      ,   QuickCheck >= 2.1 && < 3.0

--- a/Haskell/BookingApi.cabal
+++ b/Haskell/BookingApi.cabal
@@ -27,7 +27,7 @@ library
 test-suite discordia
  type:                exitcode-stdio-1.0
  main-is:             Discordia.hs
- other-modules:       MaîtreD, MaîtreDTests
+ other-modules:       MaitreD, MaitreDTests
  default-language:    Haskell2010
  build-depends:                 base >= 4.8 && < 4.9
                       ,         time >= 1.5 && < 1.6

--- a/Haskell/Discordia.hs
+++ b/Haskell/Discordia.hs
@@ -1,0 +1,42 @@
+-- This module implements a basic Test Runner for testing QuickCheck properties.
+-- It's mostly identical to what xmonad does. [1][2]
+-- Given the (current) size of this codebase, that's the simplest thing that can
+-- possibly work [3], without taking on needless dependencies on other packages.
+-- It's named Discordia, after Eris (/ˈɪərɪs, ˈɛrɪs/; Greek: Ἔρις, "Strife") the
+-- Greek goddess of strife 'n discord. Eris is the equivalent of Latin Discordia
+-- which means "discord".
+--
+-- 1. https://github.com/xmonad/xmonad/blob/f03d2cdf74288bb3632b601ccd43bf02b0da4532/tests/Properties.hs#L27-L44
+--
+-- 2. xmonad scores currently 22 points in the (Haskell) Reddit: "What are some
+--    examples of really good Haskell code?"
+--    https://www.reddit.com/r/haskell/comments/2udvkh/what_are_some_examples_of_really_good_haskell_code/
+--
+-- 3. http://wiki.c2.com/?DoTheSimplestThingThatCouldPossiblyWork
+--
+
+import           Control.Monad   (unless)
+import           MaîtreDTests
+import           Test.QuickCheck (Property, Result (..), maxSize, maxSuccess,
+                                  property, quickCheckWithResult, stdArgs)
+import           Text.Printf     (printf)
+
+tests :: [(String, Property)]
+tests =
+  [ ("tryAccept behaves correctly when it can accept"
+    , property tryAcceptBehavesCorrectlyWhenItCanAccept)
+
+  , ("tryAccept behaves correctly when it can not accept"
+    , property tryAcceptBehavesCorrectlyWhenItCanNotAccept) ]
+
+main :: IO ()
+main = do
+  let args = stdArgs { maxSuccess = 100, maxSize = 100 }
+      qc t = do
+        c <- quickCheckWithResult args t
+        case c of
+          Success{} -> return True
+          _         -> return False
+      perform (s, t) = printf "%-35s: " s >> qc t
+  n <- length . filter not <$> mapM perform tests
+  unless (n == 0) (error (show n ++ " test(s) failed"))

--- a/Haskell/Discordia.hs
+++ b/Haskell/Discordia.hs
@@ -16,7 +16,7 @@
 --
 
 import           Control.Monad   (unless)
-import           MaîtreDTests
+import           MaitreDTests
 import           Test.QuickCheck (Property, Result (..), maxSize, maxSuccess,
                                   property, quickCheckWithResult, stdArgs)
 import           Text.Printf     (printf)


### PR DESCRIPTION
by running `stack test`.

---

As mentioned also [here](https://github.com/ploeh/dependency-rejection-samples/pull/3), it can be possible that `stack test` will not be able to load the modules because of the *MaîtreDXyz* filenames.

Notice the "*Ma├«treDTests.o: No such file or directory*" below:

```
$ stack test
BookingApi-0.1.0.0: build (lib + test)
Preprocessing library BookingApi-0.1.0.0...
[1 of 4] Compiling MaîtreD          ( MaîtreD.hs, .stack-work\dist\2672c1f3\build\MaîtreD.o )
[2 of 4] Compiling MaîtreDTests     ( MaîtreDTests.hs, .stack-work\dist\2672c1f3\build\MaîtreDTests.o )
[3 of 4] Compiling DB               ( DB.hs, .stack-work\dist\2672c1f3\build\DB.o )
[4 of 4] Compiling Composition      ( Composition.hs, .stack-work\dist\2672c1f3\build\Composition.o )
In-place registering BookingApi-0.1.0.0...
Preprocessing test suite 'discordia' for BookingApi-0.1.0.0...
[1 of 3] Compiling MaîtreD          ( MaîtreD.hs, .stack-work\dist\2672c1f3\build\discordia\discordia-tmp\MaîtreD.o )
[2 of 3] Compiling MaîtreDTests     ( MaîtreDTests.hs, .stack-work\dist\2672c1f3\build\discordia\discordia-tmp\MaîtreDTests.o )
[3 of 3] Compiling Main             ( Discordia.hs, .stack-work\dist\2672c1f3\build\discordia\discordia-tmp\Main.o )
Linking .stack-work\dist\2672c1f3\build\discordia\discordia.exe ...
realgcc.exe: error: .stack-work\dist\2672c1f3\build\discordia\discordia-tmp\Ma├«treDTests.o: No such file or directory
realgcc.exe: error: .stack-work\dist\2672c1f3\build\discordia\discordia-tmp\Ma├«treD.o: No such file or directory

--  While building package BookingApi-0.1.0.0 using:
      C:\sr\setup-exe-cache\x86_64-windows\Cabal-simple_Z6RU0evB_1.22.5.0_ghc-7.10.3.exe --builddir=.stack-work\dist\2672c1f3 build lib:BookingApi test:discordia --ghc-options " -ddump-hi -ddump-to-file"
    Process exited with code: ExitFailure 1
Progress: 1/2
```

---

However, everything seems to work when I rename *MaîtreD* to *MaitreD* and *MaîtreDTests* to *MaitreDTests*:

```
$ stack test
BookingApi-0.1.0.0: build (lib + test)
Preprocessing library BookingApi-0.1.0.0...
In-place registering BookingApi-0.1.0.0...
Preprocessing test suite 'discordia' for BookingApi-0.1.0.0...
[3 of 3] Compiling Main             ( Discordia.hs, .stack-work\dist\2672c1f3\build\discordia\discordia-tmp\Main.o )
Linking .stack-work\dist\2672c1f3\build\discordia\discordia.exe ...
BookingApi-0.1.0.0: copy/register
Installing library in
C:\Users\Nikos\Documents\dependency-rejection-samples\Haskell\.stack-work\install\4cd6b5f1\lib\x86_64-windows-ghc-7.10.3\BookingApi-0.1.0.0-Hp2KjzTb44a8SAanX5uJ4C
Registering BookingApi-0.1.0.0...
BookingApi-0.1.0.0: test (suite: discordia)

tryAccept behaves correctly when it can accept: +++ OK, passed 100 tests.
tryAccept behaves correctly when it can not accept: +++ OK, passed 100 tests.

Completed 2 action(s).
```

Then, running `stack test` again is faster when there are no file changes:

```
$ stack test
BookingApi-0.1.0.0: test (suite: discordia)

tryAccept behaves correctly when it can accept: +++ OK, passed 100 tests.
tryAccept behaves correctly when it can not accept: +++ OK, passed 100 tests.
```