### PR TITLE
Renamed all occurrences of Maître* to Maitre* in Haskell folder,

### DIFF
--- a/Haskell/BookingApi.cabal
+++ b/Haskell/BookingApi.cabal
@@ -16,7 +16,7 @@ build-type:          Simple
 cabal-version:       >= 1.10
 
 library
-  exposed-modules:     MaîtreD, MaîtreDTests, Composition, DB
+  exposed-modules:     MaitreD, MaitreDTests, Composition, DB
   default-language:    Haskell2010
   build-depends:                 base >= 4.8 && < 4.9
                        ,         time >= 1.5 && < 1.6

--- a/Haskell/Composition.hs
+++ b/Haskell/Composition.hs
@@ -2,7 +2,7 @@ module Composition where
 
 import Control.Monad.Trans (liftIO)
 import Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
-import MaîtreD
+import MaitreD
 import DB
 
 connectionString :: ConnectionString

--- a/Haskell/DB.hs
+++ b/Haskell/DB.hs
@@ -2,7 +2,7 @@
 module DB where
 
 import Data.Time (ZonedTime)
-import MaîtreD
+import MaitreD
 
 type ConnectionString = String
 

--- a/Haskell/MaitreD.hs
+++ b/Haskell/MaitreD.hs
@@ -1,4 +1,4 @@
-module MaîtreD where
+module MaitreD where
 
 import Data.Time (ZonedTime (..))
 

--- a/Haskell/MaitreDTests.hs
+++ b/Haskell/MaitreDTests.hs
@@ -1,6 +1,6 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module MaîtreDTests
+module MaitreDTests
     ( tryAcceptBehavesCorrectlyWhenItCanAccept
     , tryAcceptBehavesCorrectlyWhenItCanNotAccept
     ) where
@@ -10,7 +10,7 @@ import           Data.Maybe         (isNothing)
 import           Data.Time          (LocalTime (..), ZonedTime (..), midnight,
                                      utc)
 import           Data.Time.Calendar (fromGregorian, gregorianMonthLength)
-import           MaîtreD
+import           MaitreD
 import           Test.QuickCheck
 
 instance Arbitrary ZonedTime where


### PR DESCRIPTION
because of the Unicode issues discussed in:

 - https://github.com/ploeh/dependency-rejection-samples/pull/3
 - https://github.com/ploeh/dependency-rejection-samples/pull/6